### PR TITLE
Add typst-action

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Official project links.
 - [typst-bot](https://github.com/mattfbacon/typst-bot): A discord bot to render Typst code
 - [typst-fmt](https://github.com/astrale-sharp/typst-fmt/): An in development Typst formatter (PR welcomed)
 - [typst-pandoc](https://github.com/lvignoli/typst-pandoc): Typst custom reader and writer for Pandoc
+- [typst-action](https://github.com/lvignoli/typst-action): Build Typst documents using GitHub actions
 
 ## Templates & Libraries
 


### PR DESCRIPTION
Adding [typst-action](https://github.com/lvignoli/typst-action), a GitHub action to build Typst files.
Useful for CI/CD and release of fresh PDFs on push of new commits.