### PR TITLE
Added typst-theorems to Mathematics

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Official project links.
 
 - [commutative-diagrams](https://gitlab.com/giacomogallina/typst-cd): A library for creating commutative diagrams
 - [typst-undergradmath](https://github.com/johanvx/typst-undergradmath): A Typst port of [undergradmath](https://gitlab.com/jim.hefferon/undergradmath)
+- [typst-theorems](https://github.com/sahasatvik/typst-theorems): A library for creating numbered theorem environments
 
 ### Physics
 


### PR DESCRIPTION
This PR adds [typst-theorems](https://github.com/sahasatvik/typst-theorems), which helps create numbered theorem environments. These can be customized, attached to other environments, and labeled/referenced.