### PR TITLE
feat: Add setup-typst

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ PRs welcomed!
 
 ### GitHub Actions
 
+- [setup-typst](https://github.com/yusancky/setup-typst): A cross-OS action for installing Typst
 - [typst-action](https://github.com/lvignoli/typst-action): Build Typst documents using GitHub actions
 
 ### Programming


### PR DESCRIPTION
A cross-OS action for installing Typst

----

The action previously added only works on Linux because it is a Docker container action. So I created my action, which is a composite action, so it's compatible with three operating systems.