### PR TITLE
feat: Add Typst Preview VS Code Extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ PRs welcomed!
 #### VSCode
 
 - [Typst LSP VS Code Extension](https://marketplace.visualstudio.com/items?itemName=nvarner.typst-lsp)
+- [Typst Preview VS Code Extension](https://marketplace.visualstudio.com/items?itemName=mgt19937.typst-preview): Preview your Typst files in VS Code instantly
 
 ### GitHub Actions
 


### PR DESCRIPTION
[Typst Preview VS Code Extension](https://marketplace.visualstudio.com/items?itemName=mgt19937.typst-preview): Preview your Typst files in VS Code instantly

----

The author of this project thought VS Code was rendering too slowly when using Typst inside VS Code. After troubleshooting, it was partly because the webapp was exporting bitmaps directly when exporting. So he wrote this plugin to implement a more real-time preview.