### PR TITLE
Add typst-http-api

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ PRs welcomed!
     - [Editor Integrations](#editor-integrations)
     - [CI/CD](#cicd)
     - [Programming](#programming)
+    - [Typst As A Service](#typst-as-a-service)
   - [Templates & Libraries](#templates--libraries)
     - [Official](#official)
     - [General](#general)
@@ -95,6 +96,10 @@ PRs welcomed!
 
 - [leetcode.typ](https://github.com/lucifer1004/leetcode.typ) - Solving Leetcode problems in Typst
 - [typst-py](https://github.com/messense/typst-py) - Python binding to typst
+
+### Typst As A Service
+
+- [typst-http-api](https://github.com/slashformotion/typst-http-api) - An simple docker containing an API to compile typst markup
 
 ## Templates & Libraries
 


### PR DESCRIPTION
An simple docker containing an API to compile typst markup. 

It allow developers to self-host this docker container and consume the api to compile typst documents As A Service. Since the python code use the rust bindings under the hood the compilation is very fast and does not consume a lot of resources. It can even be hosted on PAAS such as render.com for free. 

**Repo URL**: https://github.com/slashformotion/typst-http-api
