### PR TITLE
Add typst-glossary to general section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ PRs welcomed!
 - [tyspt-mla9-template](https://github.com/wychwitch/tyspt-mla9-template) - An MLA 9th edition template
 - [writable-gm-screen-inserts](https://github.com/LLBlumire/writable-gm-screen-inserts) - Writable Game Master Screen Inserts
 - [typst-index](https://github.com/RolfBremer/typst-index) - Automatically Generated Index Page
+- [typst-glossary](https://github.com/RolfBremer/typst-glossary) - Automatically Generated Glossary Page
 
 ### Assignments
 


### PR DESCRIPTION
**Repo URL**: https://github.com/RolfBremer/typst-glossary
