### PR TITLE
typst-canvas: Update name and description

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ PRs welcomed!
 
 ### Graphics
 
-- [typst-canvas](https://github.com/johannes-wolf/typst-canvas) - A library for drawing things
+- [CeTZ](https://github.com/johannes-wolf/typst-canvas) - CeTZ (CeTZ, ein Typst Zeichenpacket) is a library for drawing with [Typst](https://typst.app) with an API inspired by TikZ and [Processing](https://processing.org/)
 - [typst-raytracer](https://github.com/SeniorMars/typst-raytracer) - raytracer in typst
 
 ### Letters


### PR DESCRIPTION
**Repo URL**: https://github.com/johannes-wolf/typst-canvas

Update project name (to the name used for `packages`) and the description to the one from the repository.