### PR TITLE
updated commutative diagrams library's name and repo link

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,1 +1,2 @@
 twitter.com
+linkedin.com

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ PRs welcomed!
 - [typst-glossary](https://github.com/RolfBremer/typst-glossary) - Automatically Generated Glossary Page
 - [typst-invoice](https://github.com/erictapen/typst-invoice) - Generate invoices from TOML files
 - [Typst-Paper-Template](https://github.com/jxpeng98/Typst-Paper-Template) - Typst template for Working Paper
+
 ### Assignments
 
 - [assignment-template](https://github.com/AntoniosBarotsis/typst-assignment-template) - A simple assignment template

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ PRs welcomed!
 - [gloss-awe](https://github.com/RolfBremer/gloss-awe) - Automatically Generated Glossary Page (renamed from typst-glossary)
 - [typst-invoice](https://github.com/erictapen/typst-invoice) - Generate invoices from TOML files
 - [Typst-Paper-Template](https://github.com/jxpeng98/Typst-Paper-Template) - Typst template for Working Paper
-- [typst-uwthesis](https://github.com/yangwenbo99/typst-uwthesis) - A typst template for writing thesis, featuring a working abbreviation lists. 
+- [typst-uwthesis](https://github.com/yangwenbo99/typst-uwthesis) - A typst template for writing thesis, featuring a working abbreviation lists.
 
 ### Assignments
 

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ PRs welcomed!
 
 ### Music
 
-- [typst-chords](https://github.com/ljgago/typst-chords) - A library to write song lyrics with chord diagrams in Typst 
+- [typst-chords](https://github.com/ljgago/typst-chords) - A library to write song lyrics with chord diagrams in Typst
 
 ### Physics
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ PRs welcomed!
     - [CLI Tools](#cli-tools)
     - [Editors](#editors)
     - [Editor Integrations](#editor-integrations)
-    - [CI/CD](#ci-cd)
+    - [CI/CD](#cicd)
     - [Programming](#programming)
   - [Templates & Libraries](#templates--libraries)
     - [Official](#official)

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ PRs welcomed!
 
 ### Mathematics
 
-- [commutative-diagrams](https://gitlab.com/giacomogallina/typst-cd) - A library for creating commutative diagrams
+- [commute](https://gitlab.com/giacomogallina/commute) - A library for creating commutative diagrams
 - [typst-algorithms](https://github.com/platformer/typst-algorithms) - A library for writing algorithms
 - [typst-theorems](https://github.com/sahasatvik/typst-theorems) - A library for creating numbered theorem environments
 - [typst-undergradmath](https://github.com/johanvx/typst-undergradmath) - A Typst port of [undergradmath](https://gitlab.com/jim.hefferon/undergradmath)

--- a/README.md
+++ b/README.md
@@ -87,9 +87,9 @@ PRs welcomed!
 
 ### CI/CD
 
+- [gitlab-ci-typst](https://gitlab.com/IvanSanchez/gitlab-ci-typst) - Build Typst documents using GitLab CI pipelines
 - [setup-typst](https://github.com/yusancky/setup-typst) - A cross-OS github action for installing Typst
 - [typst-action](https://github.com/lvignoli/typst-action) - Build Typst documents using GitHub actions
-- [gitlab-ci-typst](https://gitlab.com/IvanSanchez/gitlab-ci-typst) - Build Typst documents using GitLab CI pipelines
 
 ### Programming
 


### PR DESCRIPTION
Hi, i'm the autor of the commutative diagrams library. In order to add my library to the package manager, i had to change its name (and i also changed the repo's link). This pull request should update the corresponding entry in the readme. Many thanks for this repo by the way, it's incredibly useful and very organized!
