### PR TITLE
Change name of typst-slides to polylux

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ PRs welcomed!
 ### Slides
 
 - [diapo](https://github.com/lvignoli/diapo) - A minimal and simplistic presentation template.
-- [typst-slides](https://github.com/andreasKroepelin/typst-slides) - A template for creating slides in Typst
+- [polylux](https://github.com/andreasKroepelin/polylux) - Create presentation slides in Typst
 
 <!-- Local Variables: -->
 <!-- markdown-toc-header-toc-title: "## Contents" -->


### PR DESCRIPTION
**Repo URL**: https://github.com/andreasKroepelin/polylux

The former `typst-slides` has been renamed to `polylux`.