### PR TITLE
typst-strfmt renamed to typst-oxifmt

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ PRs welcomed!
 
 ### Scripting
 
-- [typst-strfmt](https://github.com/PgBiel/typst-strfmt) - Convenient Rust-like string formatting in Typst
+- [typst-oxifmt](https://github.com/PgBiel/typst-oxifmt) - Convenient Rust-like string formatting in Typst
 
 ### Slides
 


### PR DESCRIPTION
**Repo URL**: https://github.com/PgBiel/typst-oxifmt

This PR just updates my "strfmt" package's name to "oxifmt" (renamed as it was published to the official package manager). Also updates the repo link.