### PR TITLE
Add typst-cv-template1 to CV list, update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ PRs welcomed!
 - [typst-twentysecondcv](https://github.com/tomowang/typst-twentysecondcv) - A CV template inspired by LaTeX's `Twenty Seconds Resume/CV`
 - [typst-yaml-cv](https://github.com/daxartio/cv) - A simple cv template designed using typst and yaml.
 - [vercanard](https://github.com/elegaanz/vercanard) - A colorful resume template for Typst
+- [typst-cv-template1](https://github.com/vaibhavjhawar/typst-cv-template1) - A CV template inspired by Alessandro Plasmati's Graduate CV LaTex template
 
 ### Calendar / Timetable
 


### PR DESCRIPTION
**Repo URL**:
https://github.com/vaibhavjhawar/typst-cv-template1

A Typst Resume/CV template
Inspired by Alessandro Plasmati's Graduate CV LaTex template