### PR TITLE
feat: Add ieee-trans-typst into README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ PRs welcomed!
 - [Typst-Paper-Template](https://github.com/jxpeng98/Typst-Paper-Template) - Typst template for Working Paper
 - [gloss-awe](https://github.com/RolfBremer/gloss-awe) - Automatically Generated Glossary Page (renamed from typst-glossary)
 - [ieee-typst-template](https://github.com/bsp0109/ieee-typst-template) - A template to write IEEE Papers in Typst
+- [ieee-trans-typst](https://github.com/p4perf4ce/typst-ieee-trans-template) - A template that mimic LaTeX IEEE Transaction template (`ieee-trans.cls`)
 - [in-dexter](https://github.com/RolfBremer/in-dexter) - Automatically Generated Index Page (renamed from typst-index)
 - [simple-typst-thesis](https://github.com/zagoli/simple-typst-thesis) - A template useful for writing simple thesis in Typst
 - [typst-invoice](https://github.com/erictapen/typst-invoice) - Generate invoices from TOML files


### PR DESCRIPTION
**Repo URL**:
https://github.com/p4perf4ce/typst-ieee-trans-template

A template that mimic [IEEETran.cls/ieee-trans.cls](https://[ewh.ieee.org/conf/ijcnn/2003/IEEEtran.cls](https://ewh.ieee.org/conf/ijcnn/2003/IEEEtran.cls)) but in Typst instead of LaTeX.