### PR TITLE
Add a template for AIAA formatted papers to the list.

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ PRs welcomed!
 - [tyspt-mla9-template](https://github.com/wychwitch/tyspt-mla9-template) - An MLA 9th edition template
 - [writable-gm-screen-inserts](https://github.com/LLBlumire/writable-gm-screen-inserts) - Writable Game Master Screen Inserts
 - [french-association-status](https://github.com/coco33920/typst-association-status) - A Template to write status for french associations.
+- [aiaa-typst-template](https://gitlab.com/waterlubber/aiaa-typst-template) - A template for AIAA (American Institute of Aeronautics and Astronautics) papers.
 
 ### Assignments
 


### PR DESCRIPTION
I'm not completely sure where the most appropriate location for this template is. It's not an "official quality" template, but handles the vast majority of the tricky legwork for getting AIAA formatting working. It took quite a while to write, so I'd like to save everyone else's time in the future.

PR Source Repo:
https://github.com/waterlubber/awesome-typst

Template Repo:
https://gitlab.com/waterlubber/aiaa-typst-template

If there are any other criteria for templates, or any other places people frequently check, please let me know. There's no point making a template if I'm not going to share it!
