### PR TITLE
fix some typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ PRs welcomed!
 - [typst-ansi_render](https://github.com/8LWXpg/typst-ansi_render) - A library to render text with ANSI escape sequences
 - [typst-boxes](https://github.com/lkoehl/typst-boxes) - A library to draw colorful boxes.
 - [typst-codelst](https://github.com/jneug/typst-codelst) - A Typst package to render source code.
-  [term](https://github.com/qo/term) - A Typst package for creating figures that emulate terminal screenshots.
+- [term](https://github.com/qo/term) - A Typst package for creating figures that emulate terminal screenshots.
 - [typst-diagbox](https://github.com/PgBiel/typst-diagbox) - A library for diagonal line dividers in Typst tables
 - [typst-tablex](https://github.com/PgBiel/typst-tablex) - More powerful and customizable tables in Typst!
 - [typst-tablem](https://github.com/OrangeX4/typst-tablem) - Write markdown-like tables easily.

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ PRs welcomed!
 - [leipzig-gloss](https://gitea.everydayimshuflin.com/greg/typst-lepizig-glossing) - A library that provides primitives for creating glossing rules according to Leipzig.
 - [typst-ipa](https://github.com/imatpot/typst-ipa) - 🔄 ASCII / IPA conversion for Typst
 - [typst-dictionary-template](https://kianting.info/wiki/w/Project:typst-dictionary-template) - 📕  a template for lexical dictionary/glossary in Typst
-- [typst-syntree]([https://github.com/lynn](https://github.com/lynn/typst-syntree) - Syntax trees for typst
+- [typst-syntree](https://github.com/lynn/typst-syntree) - Syntax trees for typst
 
 ### Mathematics
 


### PR DESCRIPTION
1. make `qo/term` package a separate list item (forgot to do it in another commit)
2. fix what i believe to be a typo (see the screenshot below) in `lynn/typst-syntree` package link

![image](https://github.com/qjcg/awesome-typst/assets/72982727/8fc007dd-d1b1-4c33-92f7-56a49fd66beb)

