### PR TITLE
Add [uben0/tree-sitter-typst](https://github.com/uben0/tree-sitter-ty…

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ PRs welcomed!
 - [typst.vim](https://github.com/kaarmu/typst.vim) - Vim plugin for Typst
 - [typst-conceal.vim](https://github.com/MrPicklePinosaur/typst-conceal.vim) - Vim/Nvim plugin for replacing long typst symbol names with unicode characters
 - [Typst Sync](https://github.com/OrangeX4/vscode-typst-sync) - A vscode extension for Typst local packages management and synchronization.
+- [uben0/tree-sitter-typst](https://github.com/uben0/tree-sitter-typst) - A TreeSitter grammar for the Typst language, used by Helix
 
 ### Programming
 


### PR DESCRIPTION
Add treesitter grammar by uben0. This grammar is used natively by Helix, works on emacs, and links to a repo that adds it to nvim-treesitter. The other treesitter parsers in the list appear to not be very active, I don't know if they should be removed or if more notes should be added to clarify the differences between the three different repos?

**Repo URL**: [uben0/tree-sitter-typst](https://github.com/uben0/tree-sitter-typst)
