### PR TITLE
Fix tablem link in chinese version

### DIFF
--- a/README_ZH.md
+++ b/README_ZH.md
@@ -248,7 +248,7 @@ Typst 是可用于出版的可编程标记语言，拥有变量、函数与包�
 - [typst-codelst](https://github.com/jneug/typst-codelst) - 用于呈现源代码的 Typst 包
 - [typst-diagbox](https://github.com/PgBiel/typst-diagbox) - 用于 Typst 表格中的对角线分隔线的库
 - [typst-tablex](https://github.com/PgBiel/typst-tablex) - 更强大和可定制的 Typst 表格
-- [typst-tablem](https://github.com/PgBiel/typst-tablex) - 在 Typst 中轻松编写类 markdown 表格
+- [typst-tablem](https://github.com/OrangeX4/typst-tablem) - 在 Typst 中轻松编写类 markdown 表格
 
 ### 图形
 


### PR DESCRIPTION
The link of tablem in Chinese Awesome Typst seem to be incorrect, and it pointed to typst-tablex, this PR has fixed that.