### PR TITLE
Add friggeri-cv port to Typst

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ PRs welcomed!
 - [billryan-typst](https://github.com/gvariable/billryan-typst) - A simple and minimalist resume template, inspired by Resume by Billryan.
 - [cv.typ](https://github.com/jskherman/cv.typ) - A no-frills curriculum vitae (CV) template using Typst and YAML to version control CV data.
 - [caidan](https://github.com/cu1ch3n/caidan) - A clean and minimal food menu template.
+- [friggeri-cv](https://github.com/olligobber/friggeri-cv) - A slightly modified version of the Friggeri CV, originally created by Adrien Friggeri in LaTeX, ported to Typst.
 - [modern-typst-template](https://github.com/peterpf/modern-typst-resume) - A modern resume/CV template.
 - [modern-cv](https://github.com/peterpf/modern-typst-resume) - A modern resume and coverletter template based on `Awesome CV`
 - [moderncv.typst](https://github.com/giovanniberti/moderncv.typst) - A CV template inspired by LaTeX's `moderncv`


### PR DESCRIPTION
**Repo URL**: https://github.com/olligobber/friggeri-cv

It took me a bit of digging to find a typst port of the famous Friggeri CV template in LaTeX that I've been using.
