### PR TITLE
fix: Remove unmantained typstfmt

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,6 @@ PRs welcomed!
 
 ### CLI Tools
 
-- [typstfmt](https://github.com/astrale-sharp/typstfmt/) - Basic formatter for the Typst language with a future!
 - [typstyle](https://github.com/Enter-tainer/typstyle) - Opinionated typst code formatter focusing on aesthetic, convergence and correctness.
 - [typst-live](https://github.com/ItsEthra/typst-live) - Hot reloading of pdf in web browser
 - [typst-pandoc](https://github.com/lvignoli/typst-pandoc) - Typst custom reader and writer for Pandoc


### PR DESCRIPTION
The repository for typstfmt has been archived and the project is currently unmantained.
