### PR TITLE
Remove Editors | typststudio

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,6 @@ PRs welcomed!
 
 ### Editors
 
-- [typstudio](https://github.com/Cubxity/typstudio) - An in development desktop editor built using Tauri.
 - [Katvan](https://github.com/IgKh/katvan) - A bare-bones editor for Typst files, with a bias for Right-to-Left editing.
 - [Typstwriter](https://github.com/Bzero/typstwriter) - An integrated desktop editor for typst projects.
 - [BeauTyXT](https://github.com/soupslurpr/BeauTyXT) - A private, secure, minimalistic Text, Markdown, and Typst editor for Android


### PR DESCRIPTION
The latest commit is from 9 months ago and it looks unmaintained.

**Repo URL**: https://github.com/Cubxity/typstudio
