### PR TITLE
Add CeTZ gallery https://github.com/janosh/diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ PRs welcomed!
 ### Graphics
 
 - [CeTZ](https://github.com/cetz-package/cetz) - CeTZ (CeTZ, ein Typst Zeichenpacket) is a library for drawing with [Typst](https://typst.app) with an API inspired by TikZ and [Processing](https://processing.org/). It comes with modules for drawing plots, graphs and charts.
+- [CeTZ Diagram Gallery](https://github.com/janosh/diagrams) - covering dozens of concepts in math, physics, chemistry and machine learning. Includes source code for many diagrams in both Typst and LaTeX, so good learning resource for people coming from TikZ.
 - [typst-raytracer](https://github.com/SeniorMars/typst-raytracer) - raytracer in typst
 
 ### Letters


### PR DESCRIPTION
1. 110+ scientific diagrams, 36 of which have been translated from TikZ to CeTZ (more being added with the goal of reaching parity). visit https://diagrams.janosh.dev and select the `cetz` tag to see existing CeTZ coverage
2. Covers physics, chemistry, machine learning
3. Includes source code for many diagrams in both TikZ and CeTZ, so useful resource for LaTeX users looking to learn Typst
4. Demonstrates Typst's feature parity with LaTeX for scientific visualization

I added it to the Graphics section of the readme.