### PR TITLE
add cogsci-conference

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,7 @@ Contributions are welcome!
 ##### Conferences
 
 - [aiaa-typst](https://github.com/isaacew/aiaa-typst) - A template for creating conference papers in the style of the American Institute of Aeronautics and Astronautics.
+- [cogsci-conference](https://typst.app/universe/package/cogsci-conference) - Official template for the Cognitive Science Society (CogSci) Conference Proceedings.
 - [ieee-conference-typst-template](https://github.com/DawnEver/ieee-conference-typst-template) A template to write IEEE Conference in Typst.
 - [ieee-typst-template](https://github.com/bsp0109/ieee-typst-template) - A template to write IEEE Papers in Typst
 - [ifacconf-typst](https://github.com/avonmoll/ifacconf-typst) - A template for creating conference papers in the style of the International Federation of Automatic Control


### PR DESCRIPTION
Add [cogsci-conference](https://typst.app/universe/package/cogsci-conference) - Official template for the Cognitive Science Society (CogSci) Conference Proceedings.