### PR TITLE
Add Tylax to CLI Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Contributions are welcome!
 - [typstyle](https://github.com/typstyle-rs/typstyle) - Opinionated typst code formatter focusing on aesthetic, convergence and correctness.
 - [typst-live](https://github.com/ItsEthra/typst-live) - Hot reloading of pdf in web browser
 - [typst-pandoc](https://github.com/lvignoli/typst-pandoc) - Typst custom reader and writer for Pandoc
+- [Tylax](https://github.com/scipenai/tylax) - A bidirectional LaTeX-Typst converter based on AST parsing, with support for TikZ graphics.
 - [utpm](https://github.com/typst-community/utpm) - _Package manager_ for **[local](https://github.com/typst/packages#local-packages)** and **[remote](https://github.com/typst/packages)** Typst packages.
 - [Tyler](https://github.com/mkpoli/tyler) - Package compiler for the ease of packaging and publishing Typst libraries and templates.
 - [textlint-plugin-typst](https://github.com/textlint/textlint-plugin-typst) - [textlint](https://textlint.org/) plugin to lint Typst

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -109,6 +109,7 @@ Typst 是可用于出版的可编程标记语言，拥有变量、函数与包�
 - [typst-preview](https://github.com/Enter-tainer/typst-preview) - 在浏览器中实时预览 Typst
 - [typst-live](https://github.com/ItsEthra/typst-live) - 在 Web 浏览器中实时重新加载 PDF
 - [typst-pandoc](https://github.com/lvignoli/typst-pandoc) - Pandoc 的 Typst 自定义读写器
+- [Tylax](https://github.com/scipenai/tylax) - 一个基于 AST 解析的双向 LaTeX-Typst 转换器，支持 TikZ 图形
 
 ### 在线工具
 


### PR DESCRIPTION
**Repo URL**:https://github.com/scipenai/tylax

    Adding Tylax, a new open-source bidirectional converter between LaTeX and Typst.
    Unlike existing regex-based scripts, Tylax is built in Rust using full AST parsing (via mitex and typst-syntax). This allows it to robustly handle:
>     Complex math expressions (matrices, cases, integrals)
>     Document structures (sections, lists, tables with \multicolumn)
>     Experimental TikZ ↔ CeTZ graphics conversion
>     It supports both CLI usage (cargo install tylax) and runs in the browser via WASM.

Links
> Repository: https://github.com/scipenai/tylax
> Demo: https://convert.silkyai.cn/
> Crates.io: https://crates.io/crates/tylax