### PR TITLE
Add em-dee-pdf

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Contributions are welcome!
 
 ### CLI Tools
 
+- [em-dee-pdf](https://github.com/brendandebeasi/em-dee-pdf) - Markdown to PDF converter with 18 built-in themes, LaTeX math, syntax highlighting, and table of contents.
 - [typstyle](https://github.com/typstyle-rs/typstyle) - Opinionated typst code formatter focusing on aesthetic, convergence and correctness.
 - [typst-live](https://github.com/ItsEthra/typst-live) - Hot reloading of pdf in web browser
 - [typst-pandoc](https://github.com/lvignoli/typst-pandoc) - Typst custom reader and writer for Pandoc


### PR DESCRIPTION
## Add em-dee-pdf

[em-dee-pdf](https://github.com/brendandebeasi/em-dee-pdf) is a Markdown to PDF converter built in Rust using Typst as its typesetting engine. It features 18 built-in themes, LaTeX math support, syntax highlighting, and automatic table of contents generation.

Added to the **CLI Tools** section.