### PR TITLE
Add typos to Editors section

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Contributions are welcome!
 - [Typstwriter](https://github.com/Bzero/typstwriter) - An integrated desktop editor for typst projects.
 - [BeauTyXT](https://github.com/soupslurpr/BeauTyXT) - A private, secure, minimalistic Text, Markdown, and Typst editor for Android
 - [AcademicID](https://github.com/Academic-ID/sapienAI) - A self-hosted academic-focused AI chatbot and research workspace with a Typst, Markdown, and Text editor.
+- [typos](https://github.com/dailydaniel/typos) - A Typst-native note-taking system powered by Rust and Tauri with typed metadata, cross-references, backlinks, and knowledge graph visualization.
 
 ### Editor Integrations
 


### PR DESCRIPTION
Add [typos](https://github.com/dailydaniel/typos) to the Editors section.

A Typst-native note-taking system powered by Rust and Tauri with typed metadata, cross-references, backlinks, and knowledge graph visualization.