### PR TITLE
Add qnote to Editors section

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Contributions are welcome!
 - [TypstEdit](https://github.com/SuperMegaFort/TypstEdit) - A native MacOS Typst editor
 - [Typesetter](https://typesetter.trowell.net/) - A minimalist, local-first Typst editor for Linux
 - [typos](https://github.com/dailydaniel/typos) - A Typst-native note-taking system powered by Rust and Tauri with typed metadata, cross-references, backlinks, and knowledge graph visualization.
+- [qnote](https://github.com/Omibranch/qnote) - Minimal frameless notepad for Linux with Markdown support and PDF export via Typst, plus OCR and version history.
 
 ### Editor Integrations
 


### PR DESCRIPTION
**qnote** is a minimal frameless notepad for Linux that uses Typst as its PDF export engine.

- Markdown editing with live preview
- PDF export via Typst CLI (invoked from Rust backend)
- OCR via Tesseract
- Automatic version history
- MIT license, available on AUR

GitHub: https://github.com/Omibranch/qnote

The Typst integration is a core feature — the Rust backend calls the Typst CLI to produce native PDFs with theme support (dark/light). Fits the Editors section alongside other desktop Typst-aware editors.