### PR TITLE
Add Typst agent skills for LLM-powered editors

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Contributions are welcome!
   - [Online Tools](#online-tools)
   - [Office](#office)
   - [Programming](#programming)
+  - [Skills](#skills)
   - [Typst As A Service](#typst-as-a-service)
 - [Templates & Libraries](#templates--libraries)
   - [Official](#official)
@@ -161,6 +162,12 @@ Contributions are welcome!
 - [typst-py](https://github.com/messense/typst-py) - Python binding to typst
 - [typst-rb](https://github.com/actsasflinn/typst-rb) - Ruby binding to typst
 - [typst.ts](https://github.com/Myriad-Dreamin/typst.ts) - JavaScript binding to typst
+
+### Skills
+
+- [typst-skill](https://github.com/statzhero/typst-skill) - Agent skill for Typst markup in LLM-powered editors (Claude Code, Codex, etc.)
+- [typst-cetz-skill](https://github.com/statzhero/typst-cetz-skill) - Agent skill for CeTZ diagram generation in LLM-powered editors (Claude Code, Codex, etc.)
+- [typst-touying-skill](https://github.com/statzhero/typst-touying-skill) - Agent skill for Touying slide presentations in LLM-powered editors (Claude Code, Codex, etc.)
 
 ### Typst As A Service
 


### PR DESCRIPTION
Adds a new **Skills** subsection under Integrations & Tools with three agent skills that help LLM-powered editors (Claude Code, Codex, etc.) produce correct Typst markup:

- **typst-skill** -- Core Typst syntax, styling, math, tables, figures, citations, Quarto integration
- **typst-cetz-skill** -- CeTZ diagram generation (coordinates, primitives, anchors, marks, trees, plots)
- **typst-touying-skill** -- Touying slide presentations (themes, animations, multi-file setups)

Agent skills follow the open [Agent Skills](https://agentskills.io) standard. They load structured references into the editor's context so the model writes working Typst code instead of guessing at syntax.