### PR TITLE
Add JobSprout to Typst as a Service

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Contributions are welcome!
 
 ### Typst As A Service
 
+- [JobSprout](https://jobsprout.ai) - AI CV and cover letter builder powered by Typst. Generates ATS-friendly PDFs from multiple Typst templates with AI writing assistance.
 - [typst-http-api](https://github.com/slashformotion/typst-http-api) - An simple docker containing an API to compile typst markup
 - [typst-telegram-bot](https://github.com/daskol/typst-telegram-bot) - A plain and simple HTTP API for rendering math with Typst.
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -142,6 +142,7 @@ Typst 是可用于出版的可编程标记语言，拥有变量、函数与包�
 
 ### Typst 作为服务
 
+- [JobSprout](https://jobsprout.ai) - 基于 Typst 的 AI 简历和求职信构建器，支持多种模板和 ATS 友好的 PDF 导出。
 - [typst-http-api](https://github.com/slashformotion/typst-http-api) - 包含 API 的简单 Docker，用于编译 Typst 标记
 
 ## 模板和库


### PR DESCRIPTION
[JobSprout](https://jobsprout.ai) is an AI-powered CV and cover letter builder that uses Typst as its typesetting engine. It ships multiple Typst templates and renders ATS-friendly PDFs via Typst WASM. Adding under Typst as a Service since it exposes Typst rendering through a web application.

Made with [Cursor](https://cursor.com)