### PR TITLE
chore: add Gribouille library to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,7 @@ Contributions are welcome!
 - [typst-cd](https://gitlab.com/giacomogallina/commute) - Proof of Concept for tikz-like commutative diagrams
 - [typst-plot](https://github.com/johannes-wolf/typst-plot) - A library for plotting line charts (deprecated in favor of CeTZ)
 - [typst-plotting](https://github.com/Chayraaa/typst-plotting) - A library for drawing a variety of charts and plots like line charts, histograms, and pie charts
+- [Gribouille](https://github.com/mcanouil/gribouille) - Create elegant graphics with the Grammar of Graphics for Typst.
 
 ### Posters
 


### PR DESCRIPTION
**Repo URL**: https://github.com/mcanouil/gribouille

Docs: https://m.canouil.dev/gribouille/
