### PR TITLE
Add imprint to CLI Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Contributions are welcome!
 ### CLI Tools
 
 - [em-dee-pdf](https://github.com/brendandebeasi/em-dee-pdf) - Markdown to PDF converter with 18 built-in themes, LaTeX math, syntax highlighting, and table of contents.
+- [imprint](https://github.com/gunasekar/imprint) - Markdown to branded, typeset PDFs via Typst, with reusable house styles, profiles, and deterministic output.
 - [typstyle](https://github.com/typstyle-rs/typstyle) - Opinionated typst code formatter focusing on aesthetic, convergence and correctness.
 - [typst-live](https://github.com/ItsEthra/typst-live) - Hot reloading of pdf in web browser
 - [typst-pandoc](https://github.com/lvignoli/typst-pandoc) - Typst custom reader and writer for Pandoc


### PR DESCRIPTION
Adds [imprint](https://github.com/gunasekar/imprint) under **CLI Tools**.

imprint turns Markdown into branded, typeset PDFs using **Typst** (through a custom pandoc template): reusable house styles, per-org profiles (`--profile`), cover/masthead, callouts, Mermaid → SVG figures, and deterministic output. Single suggestion; placed next to em-dee-pdf (the other Markdown→PDF tool).

Repo: https://github.com/gunasekar/imprint