### PR TITLE
Add typst-templates to CV templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@ Contributions are welcome!
 - [typst-resume-sans](https://github.com/mizlan/typst-resume-sans) - A sleek and unadorned sans-serif resume template.
 - [typst-resume-template](https://github.com/bamboovir/typst-resume-template) - Aesthetic style inspired by the Awesome-CV project
 - [typst-resume-template](https://github.com/hexWars/resume) - A pretty resume template designed using typst.
+- [typst-templates](https://github.com/davidculemann/typst-templates) - A collection of 42 CV and resume designs, each a single self-contained file with no imports.
 - [typst-twentysecondcv](https://github.com/tomowang/typst-twentysecondcv) - A CV template inspired by LaTeX's `Twenty Seconds Resume/CV`
 - [typst-yaml-cv](https://github.com/daxartio/cv) - A simple cv template designed using typst and yaml.
 - [vercanard](https://github.com/elegaanz/vercanard) - A colorful resume template for Typst


### PR DESCRIPTION
Repo: https://github.com/davidculemann/typst-templates

A collection of 42 CV and resume designs rather than a single template. Each one is a standalone `main.typ` with no imports and no package dependencies, so it compiles on its own with Typst 0.12 or newer, and each has a rendered preview and a filled-in sample in the repo.

Most are MIT-0. Nine are ports of templates already on this list (brilliant-CV, fantastic-cv, academicv and others) and stay under their upstream licences, with a NOTICE recording the changes.

Added under CV > Templates, alphabetically. English README only; happy to add the README_ZH line if you would rather have both in one PR.